### PR TITLE
Improve synth UI and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# oscillab
+# Oscillab
+
+Simple modular audio synthesizer with a minimal PyQt5 interface.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the tests
+
+Execute the test suite to ensure that the audio components and the UI
+bindings work as expected:
+
+```bash
+pytest
+```
+
+## Launching the synthesizer
+
+Start the graphical interface with:
+
+```bash
+python main.py
+```
+
+The window lets you:
+
+- Choose a waveform for each oscillator.
+- Adjust each oscillator's frequency.
+- Click **Play note** to generate sound using the current settings.
+
+Experiment with the controls to modify the timbre and pitch of the generated
+note. Additional signal processors such as a low‑pass filter, delay and
+reverb are already wired in and can be extended with more widgets.
+
+In headless environments you can run the interface without display support:
+
+```bash
+QT_QPA_PLATFORM=offscreen python main.py
+```
+

--- a/interface/ui.py
+++ b/interface/ui.py
@@ -43,19 +43,31 @@ class SynthUI(QtWidgets.QMainWindow):
         layout.addWidget(QtWidgets.QLabel("Oscillator 1 waveform"))
         layout.addWidget(self.combo1)
 
+        self.freq1 = QtWidgets.QDoubleSpinBox()
+        self.freq1.setRange(20.0, 2000.0)
+        self.freq1.setValue(440.0)
+        layout.addWidget(QtWidgets.QLabel("Oscillator 1 frequency"))
+        layout.addWidget(self.freq1)
+
         self.combo2 = QtWidgets.QComboBox()
         self.combo2.addItems(waveforms)
         self.combo2.currentTextChanged.connect(lambda w: setattr(self.osc2, "waveform", w))
         layout.addWidget(QtWidgets.QLabel("Oscillator 2 waveform"))
         layout.addWidget(self.combo2)
 
-        play_btn = QtWidgets.QPushButton("Play A4")
+        self.freq2 = QtWidgets.QDoubleSpinBox()
+        self.freq2.setRange(20.0, 2000.0)
+        self.freq2.setValue(440.0)
+        layout.addWidget(QtWidgets.QLabel("Oscillator 2 frequency"))
+        layout.addWidget(self.freq2)
+
+        play_btn = QtWidgets.QPushButton("Play note")
         play_btn.clicked.connect(self.play_note)
         layout.addWidget(play_btn)
 
     def play_note(self) -> None:
-        self.osc1.frequency = 440.0
-        self.osc2.frequency = 440.0
+        self.osc1.frequency = self.freq1.value()
+        self.osc2.frequency = self.freq2.value()
         self.mixer.play(1.0)
 
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,8 @@
-# Placeholder main entry for synthesizer project.
+"""Entry point for the Oscillab synthesizer."""
+
+from interface.ui import run
+
 
 if __name__ == "__main__":
-    pass
+    run()
+


### PR DESCRIPTION
## Summary
- Add frequency controls to the PyQt5 interface and hook them into playback
- Provide a runnable main entry point
- Expand README with installation, testing and usage instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68951f11d0cc8330924119487413f8b4